### PR TITLE
Update travel-grant.md

### DIFF
--- a/docs/travel-support/travel-grant.md
+++ b/docs/travel-support/travel-grant.md
@@ -97,7 +97,7 @@ Once the application is prepared, please submit it by filing a bug on Launchpad.
 - For `Summary` field, enter `[Travel grant - UbuCon Asia <Year>] - <Your name>`. (e.g. `[Travel grant - UbuCon Asia 2024] - John Doe`)
 - For `Further information` field, copy and paste the full application text you have prepared before.
 - For `This bug contains information that is:` option, Make sure to choose `Private`
-- To add an attachment, Click `Extra options`. Then choose a file to attach. Unfortunately, Launchpad seem to support only single attachment for each post(a bug description or a comment on bug). To attach multiple attachments, you may add multiple comments with files attached.
+- To add an attachment, Click `Extra options`. Then choose a file to attach. Unfortunately, Launchpad seem to support only single attachment for each post(a bug description or a comment on bug). To attach multiple attachments, you may add multiple comments with files attached.You can also attach multiple files one by one after the initial submission from the bugs page of launchpad.net by clicking add attachment or patch link.
 
 Once you submit your application by filing a bug, The committee will check and review your application. Committee staff may leave comments to ask questions about your application or to provide updates on your application. The committee will also provide review result (either approved or rejected) by leaving a comment. While leaving comments does give you some email notifications, you'll still need to follow up on such notifications and updates.  
 


### PR DESCRIPTION
Added information about attachinhg multiple files . Launchpad.net initially allows only one file attachment per submission, but additional files can be added later.
<br>
![ezgif com-animated-gif-maker](https://github.com/ubucon-asia/docs.ubucon.asia/assets/115912104/f48ade9d-b9d7-4191-91e5-eedf1d8bf0b4)

